### PR TITLE
Update lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           components: rustfmt
 
       - name: Check Formatting
-        run: rustfmt --check src/*rs
+        run: rustfmt --check src/*.rs
 
   Test:
     strategy:


### PR DESCRIPTION
I have a folder in `/src` and the existing command fails ci, saying that it can't format a folder. This change fixes that and format checks all files within folder too.