### PR TITLE
feat: Added delete_documents_kapiche

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -131,7 +131,8 @@ impl IndexWriter {
         field_value: &PyAny,
     ) -> PyResult<u64> {
         let field = get_field(&self.schema, field_name)?;
-        let field_value_type = self.schema.get_field_entry(field).field_type().value_type();
+        let field_value_type =
+            self.schema.get_field_entry(field).field_type().value_type();
         let term = match field_value_type {
             Type::U64 => {
                 let value: u64 = field_value.extract::<u64>()?;

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,7 +1,13 @@
 #![allow(clippy::new_ret_no_self)]
 
-use pyo3::{exceptions, prelude::*, types::PyAny};
+use pyo3::{
+    exceptions,
+    prelude::*,
+    types::{ PyAny, PyDateTime, PyDateAccess, PyTimeAccess, PyInt },
+};
 
+use chrono::{offset::TimeZone, Utc};
+use crate::facet::Facet;
 use crate::{
     document::{extract_value, Document},
     filters::get_stopwords_filter_en,
@@ -17,7 +23,7 @@ use crate::{
 use tantivy as tv;
 use tantivy::{
     directory::MmapDirectory,
-    schema::{NamedFieldDocument, Term, Value},
+    schema::{NamedFieldDocument, Term, Value, Type},
     tokenizer::{
         Language, LowerCaser, RemoveLongFilter, SimpleTokenizer, Stemmer,
         StopWordFilter, TextAnalyzer, WhitespaceTokenizer,
@@ -106,6 +112,85 @@ impl IndexWriter {
     #[getter]
     fn commit_opstamp(&self) -> u64 {
         self.inner_index_writer.commit_opstamp()
+    }
+
+    /// Delete all documents containing a given term.
+    /// This function checks the type of the field and then converts the given value to
+    /// that particular type, instead of the other way around.
+    ///
+    /// Args:
+    ///     field_name (str): The field name for which we want to filter deleted docs.
+    ///     field_value (PyAny): Python object with the value we want to filter.
+    ///
+    /// If the field_name is not on the schema raises ValueError exception.
+    /// If the field_value is not supported raises Exception.
+    fn delete_documents_kapiche(
+        &mut self,
+        field_name: &str,
+        field_value: &PyAny,
+    ) -> PyResult<u64> {
+        let field = get_field(&self.schema, field_name)?;
+        let field_value_type = self.schema.get_field_entry(field).field_type().value_type();
+        let term = match field_value_type {
+            Type::U64 => {
+                let value: u64 = field_value.extract::<u64>()?;
+                Ok(Term::from_field_u64(field, value))
+            },
+            Type::I64 => {
+                let value: i64 = field_value.extract::<i64>()?;
+                Ok(Term::from_field_i64(field, value))
+            },
+            Type::Str => {
+                let value: String = field_value.extract::<String>()?;
+                Ok(Term::from_field_text(field, &value))
+            },
+            Type::F64 => {
+                let value: f64 = field_value.extract::<f64>()?;
+                Ok(Term::from_field_f64(field, value))
+            },
+            Type::Bool => {
+                Err(exceptions::PyValueError::new_err(format!(
+                    "Field `{field_name}` is bytes type not deletable."
+                )))
+            },
+            Type::Date => {
+                let py_datetime = field_value.downcast::<PyDateTime>()?;
+                let datetime = Utc
+                    .with_ymd_and_hms(
+                        py_datetime.get_year(),
+                        py_datetime.get_month().into(),
+                        py_datetime.get_day().into(),
+                        py_datetime.get_hour().into(),
+                        py_datetime.get_minute().into(),
+                        py_datetime.get_second().into(),
+                    )
+                .single().unwrap();
+                let value = tv::DateTime::from_timestamp_secs(
+                datetime.timestamp(),
+                );
+                Ok(Term::from_field_date(field, value))
+            },
+            Type::Facet => {
+                let value: Facet = field_value.extract::<Facet>()?;
+                Ok(Term::from_facet(field, &value.inner))
+            },
+            Type::Bytes => {
+                Err(exceptions::PyValueError::new_err(format!(
+                    "Field `{field_name}` is bytes type not deletable."
+                )))
+            },
+            Type::IpAddr => {
+                Err(exceptions::PyValueError::new_err(format!(
+                    "Field `{field_name}` is IpAddr object type and hasn not been implemented yet."
+                )))
+            },
+            Type::Json => {
+                Err(exceptions::PyValueError::new_err(format!(
+                    "Field `{field_name}` is json object type not deletable."
+                )))
+            },
+        };
+        Ok(self.inner_index_writer.delete_term(term?))
     }
 
     /// Delete all documents containing a given term.

--- a/src/index.rs
+++ b/src/index.rs
@@ -3,10 +3,9 @@
 use pyo3::{
     exceptions,
     prelude::*,
-    types::{ PyAny, PyDateTime, PyDateAccess, PyTimeAccess, PyInt },
+    types::{PyAny, PyDateAccess, PyDateTime, PyInt, PyTimeAccess},
 };
 
-use chrono::{offset::TimeZone, Utc};
 use crate::facet::Facet;
 use crate::{
     document::{extract_value, Document},
@@ -20,10 +19,12 @@ use crate::{
     searcher_frame_document::StatSearcher,
     to_pyerr,
 };
+
+use chrono::{offset::TimeZone, Utc};
 use tantivy as tv;
 use tantivy::{
     directory::MmapDirectory,
-    schema::{NamedFieldDocument, Term, Value, Type},
+    schema::{NamedFieldDocument, Term, Type, Value},
     tokenizer::{
         Language, LowerCaser, RemoveLongFilter, SimpleTokenizer, Stemmer,
         StopWordFilter, TextAnalyzer, WhitespaceTokenizer,

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -25,6 +25,7 @@ def kapiche_schema():
     return (
         SchemaBuilder()
         .add_text_field("title", stored=True)
+        .add_unsigned_field("id", stored=True, indexed=True)
         .add_text_field("body", tokenizer_name='kapiche_tokenizer')
         .build()
     )
@@ -186,6 +187,7 @@ def create_kapiche_index(dir=None):
     doc = Document()
     # create a document instance
     # add field-value pairs
+    doc.add_unsigned("id", 1)
     doc.add_text("title", "The Old Man and the Sea")
     doc.add_text(
         "body",
@@ -217,9 +219,11 @@ def create_kapiche_index(dir=None):
             ),
         }
     )
+    doc.add_unsigned('id', 3)
     writer.add_document(doc)
     writer.add_json(
         """{
+            "id": 3,
             "title": ["Frankenstein", "The Modern Prometheus"],
             "body": "You will rejoice to hear that no disaster has accompanied the commencement of an enterprise which you have regarded with such evil forebodings.  I arrived here yesterday, and my first task is to assure my dear sister of my welfare and increasing confidence in the success of my undertaking."
         }"""
@@ -297,6 +301,21 @@ class TestClass(object):
         _, doc_address = result.hits[0]
         searched_doc = index.searcher().doc(doc_address)
         assert searched_doc["title"] == ["The Old Man and the Sea"]
+
+    def test_simple_search_in_kapiche_ram(self, ram_kapiche_index):
+        index = ram_kapiche_index
+        query = index.parse_query("id:1 id:2 id:3")
+
+        result = index.searcher().search(query, 10)
+        assert len(result.hits) == 3
+        
+        writer = index.writer()
+        writer.delete_documents_kapiche('id', 1)
+        writer.commit()
+        index.reload()
+
+        result = index.searcher().search(query)
+        assert len(result.hits) == 2
 
     def test_and_query(self, ram_index):
         index = ram_index

--- a/tests/tantivy_test.py
+++ b/tests/tantivy_test.py
@@ -302,7 +302,7 @@ class TestClass(object):
         searched_doc = index.searcher().doc(doc_address)
         assert searched_doc["title"] == ["The Old Man and the Sea"]
 
-    def test_simple_search_in_kapiche_ram(self, ram_kapiche_index):
+    def test_delete_documents_kapiche(self, ram_kapiche_index):
         index = ram_kapiche_index
         query = index.parse_query("id:1 id:2 id:3")
 


### PR DESCRIPTION
Refactored delete_documents into a new function called delete_documents_kapiche. Works they way @cjrh described, where the field type is detected and then value is converted to that type, not the other way around. Works for u64 types.