### PR TITLE
expose kapiche tokenizers and add unique to count

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@ use schema::{FieldType, Schema};
 use schemabuilder::SchemaBuilder;
 use searcher::{DocAddress, Order, SearchResult, Searcher};
 use snippet::{Snippet, SnippetGenerator};
-use tokenizer::{Filter, TextAnalyzer, TextAnalyzerBuilder, Tokenizer};
 use tantivy_tokenizers::{kapiche_analyzer, kapiche_analyzer_lower};
+use tokenizer::{Filter, TextAnalyzer, TextAnalyzerBuilder, Tokenizer};
 
 /// Python bindings for the search engine library Tantivy.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ use schemabuilder::SchemaBuilder;
 use searcher::{DocAddress, Order, SearchResult, Searcher};
 use snippet::{Snippet, SnippetGenerator};
 use tokenizer::{Filter, TextAnalyzer, TextAnalyzerBuilder, Tokenizer};
+use tantivy_tokenizers::{kapiche_analyzer, kapiche_analyzer_lower};
 
 /// Python bindings for the search engine library Tantivy.
 ///
@@ -104,6 +105,8 @@ fn tantivy(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
 
     m.add_function(wrap_pyfunction!(parse_query, m)?)?;
     m.add_function(wrap_pyfunction!(parse_query_lenient, m)?)?;
+    m.add_function(wrap_pyfunction!(kapiche_tokenizer_py, m)?)?;
+    m.add_function(wrap_pyfunction!(kapiche_tokenizer_lower_py, m)?)?;
 
     m.add_wrapped(wrap_pymodule!(query_parser_error))?;
 
@@ -228,4 +231,41 @@ pub(crate) fn make_term_for_type(
     };
 
     Ok(term)
+}
+
+/// Create a Kapiche text analyzer.
+///
+/// This analyzer is configured with specific tokenization and filtering
+/// rules used by Kapiche for text analysis.
+///
+/// Returns:
+///     TextAnalyzer: A configured text analyzer instance.
+///
+/// Example:
+///     >>> analyzer = tantivy.kapiche_tokenizer()
+///     >>> tokens = analyzer.analyze("Hello World")
+#[pyfunction(name = "kapiche_tokenizer")]
+fn kapiche_tokenizer_py() -> TextAnalyzer {
+    TextAnalyzer {
+        analyzer: kapiche_analyzer(),
+    }
+}
+
+/// Create a Kapiche text analyzer with lowercase normalization.
+///
+/// This analyzer is similar to kapiche_tokenizer() but includes
+/// lowercase normalization of tokens.
+///
+/// Returns:
+///     TextAnalyzer: A configured text analyzer instance with lowercase filter.
+///
+/// Example:
+///     >>> analyzer = tantivy.kapiche_tokenizer_lower()
+///     >>> tokens = analyzer.analyze("Hello World")
+///     >>> # tokens will be lowercased
+#[pyfunction(name = "kapiche_tokenizer_lower")]
+fn kapiche_tokenizer_lower_py() -> TextAnalyzer {
+    TextAnalyzer {
+        analyzer: kapiche_analyzer_lower(),
+    }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -285,10 +285,26 @@ impl TextAnalyzer {
     ///
     /// Args:
     /// - text (string): text to analyze
+    /// - unique (bool, optional): if True, count only unique tokens. Defaults to False.
     /// Returns:
-    /// - int: count of non-stopped tokens
-    fn count_tokens(&mut self, text: &str) -> usize {
-        tantivy_tokenizers::count_tokens(&mut self.analyzer, text)
+    /// - int: count of tokens (unique or total based on parameter)
+    #[pyo3(signature = (text, unique=false))]
+    fn count_tokens(&mut self, text: &str, unique: bool) -> usize {
+        let mut token_stream = self.analyzer.token_stream(text);
+
+        if unique {
+            let mut seen = std::collections::HashSet::new();
+            while token_stream.advance() {
+                seen.insert(token_stream.token().text.to_string());
+            }
+            seen.len()
+        } else {
+            let mut count = 0;
+            while token_stream.advance() {
+                count += 1;
+            }
+            count
+        }
     }
 }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -295,7 +295,10 @@ impl TextAnalyzer {
         if unique {
             let mut seen = std::collections::HashSet::new();
             while token_stream.advance() {
-                seen.insert(token_stream.token().text.to_string());
+                let token = token_stream.token();
+                if !seen.contains(token.text.as_str()) {
+                    seen.insert(token.text.to_string());
+                }
             }
             seen.len()
         } else {

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -1,0 +1,159 @@
+import tantivy
+import pytest
+
+
+class TestKapicheTokenizers:
+    """Tests for Kapiche tokenizers exposed to Python"""
+
+    def test_kapiche_tokenizer_exists(self):
+        """Test that kapiche_tokenizer() function exists and returns TextAnalyzer"""
+        analyzer = tantivy.kapiche_tokenizer()
+        assert analyzer is not None
+        assert type(analyzer).__name__ == 'TextAnalyzer'
+
+    def test_kapiche_tokenizer_lower_exists(self):
+        """Test that kapiche_tokenizer_lower() function exists and returns TextAnalyzer"""
+        analyzer = tantivy.kapiche_tokenizer_lower()
+        assert analyzer is not None
+        assert type(analyzer).__name__ == 'TextAnalyzer'
+
+    def test_kapiche_tokenizer_analyzes_text(self):
+        """Test that kapiche_tokenizer can analyze text"""
+        analyzer = tantivy.kapiche_tokenizer()
+        tokens = analyzer.analyze("hello world")
+        assert isinstance(tokens, list)
+        assert len(tokens) > 0
+
+    def test_kapiche_tokenizer_lower_lowercases(self):
+        """Test that kapiche_tokenizer_lower lowercases tokens"""
+        analyzer = tantivy.kapiche_tokenizer_lower()
+        tokens = analyzer.analyze("Hello World HELLO")
+        assert tokens == ['hello', 'world', 'hello']
+
+
+class TestCountTokens:
+    """Tests for count_tokens() method with unique parameter"""
+
+    def test_count_tokens_basic(self):
+        """Test basic token counting without unique parameter"""
+        analyzer = tantivy.kapiche_tokenizer()
+        text = "hello world hello"
+        count = analyzer.count_tokens(text)
+        assert count == 3
+
+    def test_count_tokens_unique_false(self):
+        """Test count_tokens with unique=False (explicit)"""
+        analyzer = tantivy.kapiche_tokenizer()
+        text = "hello world hello"
+        count = analyzer.count_tokens(text, unique=False)
+        assert count == 3
+
+    def test_count_tokens_unique_true(self):
+        """Test count_tokens with unique=True"""
+        analyzer = tantivy.kapiche_tokenizer()
+        text = "hello world hello"
+        unique_count = analyzer.count_tokens(text, unique=True)
+        assert unique_count == 2
+
+    def test_count_tokens_matches_analyze_total(self):
+        """Test that count_tokens(unique=False) matches len(analyze())"""
+        analyzer = tantivy.kapiche_tokenizer()
+        text = "the quick brown fox jumps over the lazy dog"
+        tokens = analyzer.analyze(text)
+        count = analyzer.count_tokens(text, unique=False)
+        assert count == len(tokens)
+
+    def test_count_tokens_matches_analyze_unique(self):
+        """Test that count_tokens(unique=True) matches len(set(analyze()))"""
+        analyzer = tantivy.kapiche_tokenizer()
+        text = "the quick brown fox jumps over the lazy dog"
+        tokens = analyzer.analyze(text)
+        unique_count = analyzer.count_tokens(text, unique=True)
+        assert unique_count == len(set(tokens))
+
+    def test_count_tokens_with_duplicates(self):
+        """Test counting with many duplicates"""
+        analyzer = tantivy.kapiche_tokenizer_lower()
+        text = "apple banana apple cherry banana apple"
+        total_count = analyzer.count_tokens(text, unique=False)
+        unique_count = analyzer.count_tokens(text, unique=True)
+        assert total_count == 6
+        assert unique_count == 3
+
+    def test_count_tokens_empty_string(self):
+        """Test counting tokens in empty string"""
+        analyzer = tantivy.kapiche_tokenizer()
+        text = ""
+        total_count = analyzer.count_tokens(text, unique=False)
+        unique_count = analyzer.count_tokens(text, unique=True)
+        assert total_count == 0
+        assert unique_count == 0
+
+    def test_count_tokens_single_token(self):
+        """Test counting with single token"""
+        analyzer = tantivy.kapiche_tokenizer()
+        text = "hello"
+        total_count = analyzer.count_tokens(text, unique=False)
+        unique_count = analyzer.count_tokens(text, unique=True)
+        assert total_count == 1
+        assert unique_count == 1
+
+    def test_count_tokens_case_sensitivity_with_lower(self):
+        """Test that lowercase analyzer treats different cases as same token"""
+        analyzer = tantivy.kapiche_tokenizer_lower()
+        text = "Hello hello HELLO"
+        total_count = analyzer.count_tokens(text, unique=False)
+        unique_count = analyzer.count_tokens(text, unique=True)
+        assert total_count == 3
+        assert unique_count == 1  # All should be lowercased to 'hello'
+
+    def test_count_tokens_large_text(self):
+        """Test counting tokens in larger text"""
+        analyzer = tantivy.kapiche_tokenizer_lower()
+        text = """
+        The quick brown fox jumps over the lazy dog.
+        The dog was sleeping under a tree.
+        The fox was very quick and clever.
+        """
+        # First verify against analyze() to get expected values
+        tokens = analyzer.analyze(text)
+        expected_total = len(tokens)
+        expected_unique = len(set(tokens))
+
+        unique_count = analyzer.count_tokens(text, unique=True)
+        total_count = analyzer.count_tokens(text, unique=False)
+
+        # Verify exact counts match analyze()
+        assert total_count == expected_total
+        assert unique_count == expected_unique
+        # Sanity check: unique should be less than total
+        assert unique_count < total_count
+
+
+class TestUsagePattern:
+    """Test the actual usage pattern mentioned in the requirements"""
+
+    def test_usage_pattern(self):
+        """Test the usage pattern: analyzer reuse with unique counting"""
+        # Get the analyzer once
+        analyzer = tantivy.kapiche_tokenizer_lower()
+
+        # Fast unique token count for unstructured text
+        unstructured_text = "The quick brown fox jumps over the lazy dog. The dog was sleeping."
+        token_count = analyzer.count_tokens(unstructured_text, unique=True)
+
+        # For sentence
+        sentence_text = "The quick brown fox jumps over the lazy dog."
+        sentence_token_count = analyzer.count_tokens(sentence_text, unique=True)
+
+        # Verify exact counts by comparing with analyze()
+        unstructured_tokens = analyzer.analyze(unstructured_text)
+        sentence_tokens = analyzer.analyze(sentence_text)
+
+        assert token_count == len(set(unstructured_tokens))
+        assert sentence_token_count == len(set(sentence_tokens))
+
+        # Unstructured has "sleeping" and "was" that sentence doesn't have
+        # So unique count should be higher
+        assert token_count == 10  # the, quick, brown, fox, jumps, over, lazy, dog, was, sleeping
+        assert sentence_token_count == 8  # the, quick, brown, fox, jumps, over, lazy, dog


### PR DESCRIPTION
After this change we can do

```
  # Get the analyzer once (could be done at module level or passed in)
  analyzer = tantivy.kapiche_tokenizer_lower()

  # Fast unique token count
  token_count = analyzer.count_tokens(unstructured_text, unique=True)
  doc.add_integer("text_token_count__", token_count)

  # For sentence
  sentence_token_count = analyzer.count_tokens(sentence_text, unique=True)
  doc.add_integer("sentence_token_count__", sentence_token_count)

```