### PR TITLE
Backport tokenizer APIs to 0.21.1

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -43,7 +43,7 @@ fn replace_apostrophes(s: &str, replacement: char) -> String {
 fn expand_stopwords_with_apostrophe_variants(
     base_stopwords: &[&str],
 ) -> Vec<String> {
-    let mut expanded = Vec::new();
+    let mut expanded = Vec::with_capacity(base_stopwords.len());
 
     for word in base_stopwords {
         if contains_apostrophe(word) {

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -4,10 +4,117 @@ pub mod possessive_contraction_filter;
 
 use filter_constants::STOPWORDS_EN;
 
-pub fn get_stopwords_filter_en() -> Vec<String> {
-    let mut words = Vec::new();
-    for word in STOPWORDS_EN {
-        words.push(String::from(word))
+/// Unicode apostrophe characters to expand stopwords with.
+const APOSTROPHES: [char; 8] = [
+    '\u{0027}', // ' - Apostrophe
+    '\u{2019}', // ' - Right single quotation mark
+    '\u{02BC}', // ʼ - Modifier letter apostrophe
+    '\u{02BB}', // ʻ - Modifier letter turned comma
+    '\u{055A}', // ՚ - Armenian apostrophe
+    '\u{A78B}', // Ꞌ - Latin capital letter saltillo
+    '\u{A78C}', // ꞌ - Latin small letter saltillo
+    '\u{FF07}', // ＇ - Fullwidth apostrophe
+];
+
+/// Check if a string contains any apostrophe character.
+fn contains_apostrophe(s: &str) -> bool {
+    s.chars().any(|c| APOSTROPHES.contains(&c))
+}
+
+/// Replace all apostrophe variants with a specific apostrophe character.
+fn replace_apostrophes(s: &str, replacement: char) -> String {
+    s.chars()
+        .map(|c| {
+            if APOSTROPHES.contains(&c) {
+                replacement
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
+/// Expand a stopword list to include all apostrophe variants.
+///
+/// For each stopword containing an apostrophe, generates versions
+/// with every unicode apostrophe variant.
+///
+/// Example: "don't" becomes ["don't", "don\u{2019}t", "don\u{02BC}t", ...]
+fn expand_stopwords_with_apostrophe_variants(
+    base_stopwords: &[&str],
+) -> Vec<String> {
+    let mut expanded = Vec::new();
+
+    for word in base_stopwords {
+        if contains_apostrophe(word) {
+            for &apos in &APOSTROPHES {
+                expanded.push(replace_apostrophes(word, apos));
+            }
+        } else {
+            expanded.push(word.to_string());
+        }
     }
-    words
+
+    expanded
+}
+
+/// Get the Kapiche custom English stopwords list with apostrophe variants expanded.
+pub fn get_stopwords_filter_en() -> Vec<String> {
+    expand_stopwords_with_apostrophe_variants(&STOPWORDS_EN)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_contains_apostrophe() {
+        assert!(contains_apostrophe("don't"));
+        assert!(contains_apostrophe("don\u{2019}t"));
+        assert!(contains_apostrophe("don\u{02BC}t"));
+        assert!(!contains_apostrophe("hello"));
+    }
+
+    #[test]
+    fn test_replace_apostrophes() {
+        assert_eq!(replace_apostrophes("don\u{2019}t", '\''), "don't");
+        assert_eq!(replace_apostrophes("don\u{02BC}t", '\''), "don't");
+        assert_eq!(replace_apostrophes("hello", '\''), "hello");
+    }
+
+    #[test]
+    fn test_expand_stopwords_no_apostrophes() {
+        let base = vec!["hello", "world"];
+        let expanded = expand_stopwords_with_apostrophe_variants(&base);
+        assert_eq!(expanded, vec!["hello", "world"]);
+    }
+
+    #[test]
+    fn test_expand_stopwords_with_apostrophe_word() {
+        let base = vec!["don't"];
+        let expanded = expand_stopwords_with_apostrophe_variants(&base);
+        assert_eq!(expanded.len(), 8);
+        assert!(expanded.contains(&"don't".to_string()));
+        assert!(expanded.contains(&"don\u{2019}t".to_string()));
+        assert!(expanded.contains(&"don\u{02BC}t".to_string()));
+    }
+
+    #[test]
+    fn test_expand_stopwords_mixed() {
+        let base = vec!["hello", "don't", "world"];
+        let expanded = expand_stopwords_with_apostrophe_variants(&base);
+        // hello + 8 variants of don't + world = 10
+        assert_eq!(expanded.len(), 10);
+        assert!(expanded.contains(&"hello".to_string()));
+        assert!(expanded.contains(&"world".to_string()));
+    }
+
+    #[test]
+    fn test_get_stopwords_filter_en_has_apostrophe_variants() {
+        let stopwords = get_stopwords_filter_en();
+        assert!(stopwords.contains(&"don't".to_string()));
+        assert!(stopwords.contains(&"don\u{2019}t".to_string()));
+        assert!(stopwords.contains(&"can't".to_string()));
+        assert!(stopwords.contains(&"can\u{2019}t".to_string()));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod schemabuilder;
 mod searcher;
 mod searcher_frame_document;
 mod snippet;
+mod tokenizer;
 
 use document::Document;
 use facet::Facet;
@@ -22,6 +23,7 @@ use schema::Schema;
 use schemabuilder::SchemaBuilder;
 use searcher::{DocAddress, Order, SearchResult, Searcher};
 use snippet::{Snippet, SnippetGenerator};
+use tokenizer::TextAnalyzer;
 
 /// Python bindings for the search engine library Tantivy.
 ///
@@ -87,6 +89,15 @@ fn tantivy(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Query>()?;
     m.add_class::<Snippet>()?;
     m.add_class::<SnippetGenerator>()?;
+    m.add_class::<TextAnalyzer>()?;
+
+    m.add_function(wrap_pyfunction!(kapiche_tokenizer_py, m)?)?;
+    m.add_function(wrap_pyfunction!(kapiche_tokenizer_lower_py, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        kapiche_tokenizer_lower_with_stopwords_py,
+        m
+    )?)?;
+
     m.add_wrapped(wrap_pymodule!(query_parser_error))?;
 
     Ok(())
@@ -153,4 +164,87 @@ pub(crate) fn get_field(
     })?;
 
     Ok(field)
+}
+
+use filters::outer_punctuation_filter::OuterPunctuationFilter;
+use filters::possessive_contraction_filter::PossessiveContractionFilter;
+use tv::tokenizer::{
+    LowerCaser, StopWordFilter, WhitespaceTokenizer,
+};
+
+/// Create a Kapiche text analyzer.
+///
+/// This analyzer is configured with specific tokenization and filtering
+/// rules used by Kapiche for text analysis.
+///
+/// Returns:
+///     TextAnalyzer: A configured text analyzer instance.
+///
+/// Example:
+///     >>> analyzer = tantivy.kapiche_tokenizer()
+///     >>> tokens = analyzer.analyze("Hello World")
+#[pyfunction(name = "kapiche_tokenizer")]
+fn kapiche_tokenizer_py() -> TextAnalyzer {
+    TextAnalyzer {
+        analyzer: tv::tokenizer::TextAnalyzer::builder(
+            WhitespaceTokenizer::default(),
+        )
+        .filter(OuterPunctuationFilter::new(vec!['#', '@']))
+        .filter(PossessiveContractionFilter)
+        .build(),
+    }
+}
+
+/// Create a Kapiche text analyzer with lowercase normalization.
+///
+/// This analyzer is similar to kapiche_tokenizer() but includes
+/// lowercase normalization of tokens.
+///
+/// Returns:
+///     TextAnalyzer: A configured text analyzer instance with lowercase filter.
+///
+/// Example:
+///     >>> analyzer = tantivy.kapiche_tokenizer_lower()
+///     >>> tokens = analyzer.analyze("Hello World")
+///     >>> # tokens will be lowercased
+#[pyfunction(name = "kapiche_tokenizer_lower")]
+fn kapiche_tokenizer_lower_py() -> TextAnalyzer {
+    TextAnalyzer {
+        analyzer: tv::tokenizer::TextAnalyzer::builder(
+            WhitespaceTokenizer::default(),
+        )
+        .filter(LowerCaser)
+        .filter(OuterPunctuationFilter::new(vec!['#', '@']))
+        .filter(PossessiveContractionFilter)
+        .build(),
+    }
+}
+
+/// Create a Kapiche text analyzer with lowercase normalization and stopword filtering.
+///
+/// This analyzer is similar to kapiche_tokenizer_lower() but includes
+/// stopword filtering using Kapiche's custom 334-word English stopword list.
+/// Use this for token counting and topic modeling.
+/// For search indexing, use kapiche_tokenizer_lower() instead.
+///
+/// Returns:
+///     TextAnalyzer: A configured text analyzer instance with stopword filtering.
+///
+/// Example:
+///     >>> analyzer = tantivy.kapiche_tokenizer_lower_with_stopwords()
+///     >>> count = analyzer.count_tokens("the quick brown fox", unique=True)
+///     >>> # count = 3 ("the" is removed as stopword)
+#[pyfunction(name = "kapiche_tokenizer_lower_with_stopwords")]
+fn kapiche_tokenizer_lower_with_stopwords_py() -> TextAnalyzer {
+    let stopwords = filters::get_stopwords_filter_en();
+    TextAnalyzer {
+        analyzer: tv::tokenizer::TextAnalyzer::builder(
+            WhitespaceTokenizer::default(),
+        )
+        .filter(LowerCaser)
+        .filter(OuterPunctuationFilter::new(vec!['#', '@']))
+        .filter(PossessiveContractionFilter)
+        .filter(StopWordFilter::remove(stopwords))
+        .build(),
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,8 +243,8 @@ fn kapiche_tokenizer_lower_with_stopwords_py() -> TextAnalyzer {
         )
         .filter(LowerCaser)
         .filter(OuterPunctuationFilter::new(vec!['#', '@']))
-        .filter(PossessiveContractionFilter)
         .filter(StopWordFilter::remove(stopwords))
+        .filter(PossessiveContractionFilter)
         .build(),
     }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,0 +1,60 @@
+use pyo3::prelude::*;
+use tantivy::tokenizer as tvt;
+
+/// Tantivy's TextAnalyzer
+///
+/// Do not instantiate this class directly.
+/// Use the factory functions like kapiche_tokenizer() instead.
+#[derive(Clone)]
+#[pyclass(module = "tantivy.tantivy")]
+pub(crate) struct TextAnalyzer {
+    pub(crate) analyzer: tvt::TextAnalyzer,
+}
+
+#[pymethods]
+impl TextAnalyzer {
+    /// Tokenize a string
+    /// Args:
+    /// - text (string): text to tokenize.
+    /// Returns:
+    /// - list(string): a list of tokens/words.
+    fn analyze(&mut self, text: &str) -> Vec<String> {
+        let mut token_stream = self.analyzer.token_stream(text);
+        let mut tokens = Vec::new();
+
+        while token_stream.advance() {
+            tokens.push(token_stream.token().text.clone());
+        }
+        tokens
+    }
+
+    /// Count tokens without materializing them into a collection.
+    /// Much faster than len(analyze(text)) for large texts.
+    ///
+    /// Args:
+    /// - text (string): text to analyze
+    /// - unique (bool, optional): if True, count only unique tokens. Defaults to False.
+    /// Returns:
+    /// - int: count of tokens (unique or total based on parameter)
+    #[pyo3(signature = (text, unique=false))]
+    fn count_tokens(&mut self, text: &str, unique: bool) -> usize {
+        let mut token_stream = self.analyzer.token_stream(text);
+
+        if unique {
+            let mut seen = std::collections::HashSet::new();
+            while token_stream.advance() {
+                let token = token_stream.token();
+                if !seen.contains(token.text.as_str()) {
+                    seen.insert(token.text.to_string());
+                }
+            }
+            seen.len()
+        } else {
+            let mut count = 0;
+            while token_stream.advance() {
+                count += 1;
+            }
+            count
+        }
+    }
+}

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -43,10 +43,7 @@ impl TextAnalyzer {
         if unique {
             let mut seen = std::collections::HashSet::new();
             while token_stream.advance() {
-                let token = token_stream.token();
-                if !seen.contains(token.text.as_str()) {
-                    seen.insert(token.text.to_string());
-                }
+                seen.insert(token_stream.token().text.clone());
             }
             seen.len()
         } else {

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -1,0 +1,103 @@
+import tantivy
+import pytest
+
+
+class TestKapicheTokenizer:
+    """Tests for kapiche_tokenizer()"""
+
+    def test_kapiche_tokenizer_basic(self):
+        analyzer = tantivy.kapiche_tokenizer()
+        tokens = analyzer.analyze("Hello World")
+        assert tokens == ["Hello", "World"]
+
+    def test_kapiche_tokenizer_punctuation_removal(self):
+        analyzer = tantivy.kapiche_tokenizer()
+        tokens = analyzer.analyze("hello! world?")
+        assert tokens == ["hello", "world"]
+
+    def test_kapiche_tokenizer_preserves_hashtags(self):
+        analyzer = tantivy.kapiche_tokenizer()
+        tokens = analyzer.analyze("#hello @world")
+        assert tokens == ["#hello", "@world"]
+
+    def test_kapiche_tokenizer_possessive_removal(self):
+        analyzer = tantivy.kapiche_tokenizer()
+        tokens = analyzer.analyze("John's book")
+        assert tokens == ["John", "book"]
+
+
+class TestKapicheTokenizerLower:
+    """Tests for kapiche_tokenizer_lower()"""
+
+    def test_kapiche_tokenizer_lower_basic(self):
+        analyzer = tantivy.kapiche_tokenizer_lower()
+        tokens = analyzer.analyze("Hello World")
+        assert tokens == ["hello", "world"]
+
+    def test_kapiche_tokenizer_lower_punctuation(self):
+        analyzer = tantivy.kapiche_tokenizer_lower()
+        tokens = analyzer.analyze("Hello! World?")
+        assert tokens == ["hello", "world"]
+
+    def test_kapiche_tokenizer_lower_possessive(self):
+        analyzer = tantivy.kapiche_tokenizer_lower()
+        tokens = analyzer.analyze("John's book")
+        assert tokens == ["john", "book"]
+
+
+class TestKapicheTokenizerWithStopwords:
+    """Tests for kapiche_tokenizer_lower_with_stopwords()"""
+
+    def test_kapiche_tokenizer_lower_with_stopwords_english(self):
+        analyzer = tantivy.kapiche_tokenizer_lower_with_stopwords()
+        tokens = analyzer.analyze("The quick brown fox")
+        assert tokens == ["quick", "brown", "fox"]
+
+    def test_count_tokens_with_stopwords(self):
+        analyzer = tantivy.kapiche_tokenizer_lower_with_stopwords()
+        count = analyzer.count_tokens("the quick brown fox and a dog", unique=True)
+        assert count == 4
+
+    def test_stopwords_with_punctuation_and_possessives(self):
+        analyzer = tantivy.kapiche_tokenizer_lower_with_stopwords()
+        tokens = analyzer.analyze("John's the best!")
+        assert tokens == ["john", "best"]
+
+    def test_case_insensitive_stopword_removal(self):
+        analyzer = tantivy.kapiche_tokenizer_lower_with_stopwords()
+        tokens = analyzer.analyze("THE QUICK")
+        assert tokens == ["quick"]
+
+
+class TestCountTokens:
+    """Tests for TextAnalyzer.count_tokens()"""
+
+    def test_count_tokens_basic(self):
+        analyzer = tantivy.kapiche_tokenizer()
+        count = analyzer.count_tokens("Hello World")
+        assert count == 2
+
+    def test_count_tokens_unique(self):
+        analyzer = tantivy.kapiche_tokenizer_lower()
+        total_count = analyzer.count_tokens("hello world hello")
+        unique_count = analyzer.count_tokens("hello world hello", unique=True)
+        assert total_count == 3
+        assert unique_count == 2
+
+    def test_count_tokens_empty(self):
+        analyzer = tantivy.kapiche_tokenizer()
+        count = analyzer.count_tokens("")
+        assert count == 0
+
+
+class TestUsagePattern:
+    """Test the actual usage pattern mentioned in the requirements"""
+
+    def test_token_counting_workflow(self):
+        analyzer = tantivy.kapiche_tokenizer_lower_with_stopwords()
+        text = "The quick brown fox jumps over the lazy dog"
+        total = analyzer.count_tokens(text)
+        unique = analyzer.count_tokens(text, unique=True)
+        assert total > 0
+        assert unique > 0
+        assert unique <= total

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -68,6 +68,16 @@ class TestKapicheTokenizerWithStopwords:
         tokens = analyzer.analyze("THE QUICK")
         assert tokens == ["quick"]
 
+    def test_unicode_apostrophe_stopwords(self):
+        """Test that stopwords with curly quotes and other unicode apostrophes are caught"""
+        analyzer = tantivy.kapiche_tokenizer_lower_with_stopwords()
+        # U+2019 RIGHT SINGLE QUOTATION MARK (curly quote)
+        tokens = analyzer.analyze("I don\u2019t like purple elephants")
+        assert tokens == ["like", "purple", "elephants"]
+        # U+02BC MODIFIER LETTER APOSTROPHE
+        tokens = analyzer.analyze("She can\u02BCt find green frogs")
+        assert tokens == ["green", "frogs"]
+
 
 class TestCountTokens:
     """Tests for TextAnalyzer.count_tokens()"""


### PR DESCRIPTION
## Summary

- Add `TextAnalyzer` Python class with `analyze()` and `count_tokens(text, unique=False)` methods
- Expose `tantivy.kapiche_tokenizer()`, `tantivy.kapiche_tokenizer_lower()`, and `tantivy.kapiche_tokenizer_lower_with_stopwords()` factory functions
- Add stopword apostrophe expansion (all 8 Unicode apostrophe variants) matching tantivy-tokenizers behaviour
- Fix filter ordering in stopwords analyzer: StopWordFilter before PossessiveContractionFilter
- Keep filters inline (tantivy-tokenizers requires tantivy 0.25, incompatible with 0.21.1)

## Test plan

- [x] All 12 Rust unit tests pass (filter tests + apostrophe expansion tests)
- [x] All 40 Python tests pass (16 new tokenizer tests + 24 existing kapiche tests)
- [x] Unicode apostrophe stopword removal verified (curly quotes, modifier letters)
- [ ] Tag as `0.21.1.kapiche6` after merge

https://claude.ai/code/session_01XqqBg4bHKpTkAnuyE8Spm2