### PR TITLE
Include tantivy-query-grammar in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,0 @@
-include Cargo.toml
-include Makefile
-include rust-toolchain
-recursive-include src *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ optional-dependencies = { dev = ["nox"] }
 
 [tool.maturin]
 bindings = "pyo3"
+include = [
+    { path = "tantivy-query-grammar/**/*", format = "sdist" },
+]
 
 [tool.pytest.ini_options]
 # Set the durations option and doctest modules


### PR DESCRIPTION
## Summary
- The linux release job runs `maturin build --sdist`, which builds a source distribution and then compiles from the extracted sdist. Maturin's sdist only auto-includes files reachable via `cargo package`, so the vendored `tantivy-query-grammar/` directory — referenced only through `[patch.crates-io]` — was omitted, and `cargo metadata` failed against the extracted sdist.
- Windows and macOS build directly from the worktree (no `--sdist`) and were unaffected.
- Add an sdist-only include rule in `pyproject.toml` so maturin ships `tantivy-query-grammar/**/*` inside the tarball.

## Test plan
- [x] Rebuild the sdist locally and confirm `tantivy-query-grammar/` is present in the tarball
- [x] Extract the sdist to a clean dir and run `cargo metadata` — succeeds
- [ ] Release workflow linux jobs succeed on next tag