### PR TITLE
ci: allow releases.astral.sh in publish harden-runner allowlist

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,6 +29,7 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             astral.sh:443
+            releases.astral.sh:443
             cdn.quay.io:443
             cdn01.quay.io:443
             cdn02.quay.io:443


### PR DESCRIPTION
## Problem

The linux publish job fails:

```
maturin 1.14.1
curl: (6) Could not resolve host: releases.astral.sh
Error: The process '/usr/bin/docker' failed with exit code 6
```

The linux build job runs `step-security/harden-runner` with `egress-policy: block`. `maturin-action` fetches a tool from `releases.astral.sh`, but the allowlist only had `astral.sh` (harden-runner matches exact hosts, not subdomains), so DNS resolution was blocked.

## Change

Add `releases.astral.sh:443` to the linux job's `allowed-endpoints`. This mirrors upstream's fix (quickwit-oss/tantivy-py#665).

Scope: only the linux job needs it — the Windows/macOS publish jobs use `egress-policy: audit`, not `block`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSzaRKMtbA1rg2V3CGajVx)_